### PR TITLE
fix: wake lock + goAsync for screen-off alarm delivery (fixes #47, #33, #29)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />

--- a/app/src/main/java/com/upnp/fakeCall/AlarmModeAlarmReceiver.kt
+++ b/app/src/main/java/com/upnp/fakeCall/AlarmModeAlarmReceiver.kt
@@ -3,93 +3,119 @@ package com.upnp.fakeCall
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.os.PowerManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class AlarmModeAlarmReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent?) {
         if (intent == null) return
-        val alarmId = intent.getLongExtra(EXTRA_ALARM_ID, 0L)
-        if (alarmId == 0L) return
+        val pendingResult = goAsync()
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
-        val callerNumber = intent.getStringExtra(EXTRA_CALLER_NUMBER).orEmpty().trim()
-        if (callerNumber.isBlank()) return
-        val callerName = intent.getStringExtra(EXTRA_CALLER_NAME).orEmpty()
-        val providerName = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-            .getString(KEY_PROVIDER_NAME, context.getString(R.string.default_provider_name))
-            .orEmpty()
+        scope.launch {
+            val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+            val wakeLock = powerManager.newWakeLock(
+                PowerManager.PARTIAL_WAKE_LOCK,
+                WAKE_LOCK_TAG
+            ).apply { acquire(WAKE_LOCK_TIMEOUT_MS) }
 
-        val messageMode = runCatching {
-            AlarmMessageMode.valueOf(
-                intent.getStringExtra(EXTRA_MESSAGE_MODE).orEmpty().ifBlank { AlarmMessageMode.APP_VOICE_TTS.name }
-            )
-        }.getOrDefault(AlarmMessageMode.APP_VOICE_TTS)
-        val ttsMessage = intent.getStringExtra(EXTRA_TTS_MESSAGE).orEmpty()
-        val repeatTtsMessage = intent.getBooleanExtra(EXTRA_REPEAT_TTS_MESSAGE, false)
-        val customAudioUri = intent.getStringExtra(EXTRA_CUSTOM_AUDIO_URI).orEmpty()
-        val customAudioName = intent.getStringExtra(EXTRA_CUSTOM_AUDIO_NAME).orEmpty()
-        val snoozeEnabled = intent.getBooleanExtra(EXTRA_SNOOZE_ENABLED, false)
-        val snoozeMinutes = intent.getIntExtra(EXTRA_SNOOZE_MINUTES, 5).coerceIn(1, 30)
-        val speakerDefault = runCatching {
-            AlarmSpeakerDefault.valueOf(
-                intent.getStringExtra(EXTRA_SPEAKER_DEFAULT).orEmpty().ifBlank { AlarmSpeakerDefault.EARPIECE.name }
-            )
-        }.getOrDefault(AlarmSpeakerDefault.EARPIECE)
+            try {
+                val alarmId = intent.getLongExtra(EXTRA_ALARM_ID, 0L)
+                if (alarmId == 0L) return@launch
 
-        applyRuntimeOverrides(
-            context = context,
-            messageMode = messageMode,
-            ttsMessage = ttsMessage,
-            repeatTtsMessage = repeatTtsMessage,
-            customAudioUri = customAudioUri,
-            customAudioName = customAudioName,
-            speakerDefault = speakerDefault,
-            snoozeEnabled = snoozeEnabled,
-            snoozeMinutes = snoozeMinutes,
-            alarmId = alarmId,
-            callerName = callerName,
-            callerNumber = callerNumber,
-            providerName = providerName
-        )
+                val callerNumber = intent.getStringExtra(EXTRA_CALLER_NUMBER).orEmpty().trim()
+                if (callerNumber.isBlank()) return@launch
+                val callerName = intent.getStringExtra(EXTRA_CALLER_NAME).orEmpty()
+                val providerName = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                    .getString(KEY_PROVIDER_NAME, context.getString(R.string.default_provider_name))
+                    .orEmpty()
 
-        val telecomHelper = TelecomHelper(context)
-        telecomHelper.registerOrUpdatePhoneAccount(providerName.ifBlank { context.getString(R.string.default_provider_name) })
-        if (telecomHelper.isAccountEnabled()) {
-            telecomHelper.triggerIncomingCall(
-                callerName = callerName,
-                callerNumber = callerNumber,
-                source = IncomingCallSource.ALARM
-            )
-        }
+                val messageMode = runCatching {
+                    AlarmMessageMode.valueOf(
+                        intent.getStringExtra(EXTRA_MESSAGE_MODE).orEmpty().ifBlank { AlarmMessageMode.APP_VOICE_TTS.name }
+                    )
+                }.getOrDefault(AlarmMessageMode.APP_VOICE_TTS)
+                val ttsMessage = intent.getStringExtra(EXTRA_TTS_MESSAGE).orEmpty()
+                val repeatTtsMessage = intent.getBooleanExtra(EXTRA_REPEAT_TTS_MESSAGE, false)
+                val customAudioUri = intent.getStringExtra(EXTRA_CUSTOM_AUDIO_URI).orEmpty()
+                val customAudioName = intent.getStringExtra(EXTRA_CUSTOM_AUDIO_NAME).orEmpty()
+                val snoozeEnabled = intent.getBooleanExtra(EXTRA_SNOOZE_ENABLED, false)
+                val snoozeMinutes = intent.getIntExtra(EXTRA_SNOOZE_MINUTES, 5).coerceIn(1, 30)
+                val speakerDefault = runCatching {
+                    AlarmSpeakerDefault.valueOf(
+                        intent.getStringExtra(EXTRA_SPEAKER_DEFAULT).orEmpty().ifBlank { AlarmSpeakerDefault.EARPIECE.name }
+                    )
+                }.getOrDefault(AlarmSpeakerDefault.EARPIECE)
 
-        val repeatDays = (intent.getIntArrayExtra(EXTRA_REPEAT_DAYS) ?: intArrayOf())
-            .toSet()
-            .filter { day -> day in 1..7 }
-            .toSet()
-        if (repeatDays.isEmpty()) {
-            AlarmModeRepository.disable(context, alarmId)
-            AlarmModeRepository.updateNextTrigger(context, alarmId, 0L)
-            AlarmModeScheduler.cancel(context, alarmId)
-            return
-        }
+                applyRuntimeOverrides(
+                    context = context,
+                    messageMode = messageMode,
+                    ttsMessage = ttsMessage,
+                    repeatTtsMessage = repeatTtsMessage,
+                    customAudioUri = customAudioUri,
+                    customAudioName = customAudioName,
+                    speakerDefault = speakerDefault,
+                    snoozeEnabled = snoozeEnabled,
+                    snoozeMinutes = snoozeMinutes,
+                    alarmId = alarmId,
+                    callerName = callerName,
+                    callerNumber = callerNumber,
+                    providerName = providerName
+                )
 
-        val alarm = AlarmModeRepository.find(context, alarmId)?.copy(
-            callerName = callerName,
-            callerNumber = callerNumber,
-            hour = intent.getIntExtra(EXTRA_HOUR, 8).coerceIn(0, 23),
-            minute = intent.getIntExtra(EXTRA_MINUTE, 0).coerceIn(0, 59),
-            repeatDays = repeatDays,
-            messageMode = messageMode,
-            ttsMessage = ttsMessage,
-            repeatTtsMessage = repeatTtsMessage,
-            customAudioUri = customAudioUri,
-            customAudioName = customAudioName,
-            snoozeEnabled = snoozeEnabled,
-            snoozeMinutes = snoozeMinutes,
-            speakerDefault = speakerDefault,
-            enabled = true
-        )
-        if (alarm != null) {
-            val next = AlarmModeScheduler.schedule(context, alarm)
-            AlarmModeRepository.upsert(context, alarm.copy(nextTriggerAtMillis = next))
+                val telecomHelper = TelecomHelper(context)
+                telecomHelper.registerOrUpdatePhoneAccount(providerName.ifBlank { context.getString(R.string.default_provider_name) })
+                if (telecomHelper.isAccountEnabled()) {
+                    telecomHelper.triggerIncomingCall(
+                        callerName = callerName,
+                        callerNumber = callerNumber,
+                        source = IncomingCallSource.ALARM
+                    )
+                }
+
+                val repeatDays = (intent.getIntArrayExtra(EXTRA_REPEAT_DAYS) ?: intArrayOf())
+                    .toSet()
+                    .filter { day -> day in 1..7 }
+                    .toSet()
+                if (repeatDays.isEmpty()) {
+                    AlarmModeRepository.disable(context, alarmId)
+                    AlarmModeRepository.updateNextTrigger(context, alarmId, 0L)
+                    AlarmModeScheduler.cancel(context, alarmId)
+                    return@launch
+                }
+
+                val alarm = AlarmModeRepository.find(context, alarmId)?.copy(
+                    callerName = callerName,
+                    callerNumber = callerNumber,
+                    hour = intent.getIntExtra(EXTRA_HOUR, 8).coerceIn(0, 23),
+                    minute = intent.getIntExtra(EXTRA_MINUTE, 0).coerceIn(0, 59),
+                    repeatDays = repeatDays,
+                    messageMode = messageMode,
+                    ttsMessage = ttsMessage,
+                    repeatTtsMessage = repeatTtsMessage,
+                    customAudioUri = customAudioUri,
+                    customAudioName = customAudioName,
+                    snoozeEnabled = snoozeEnabled,
+                    snoozeMinutes = snoozeMinutes,
+                    speakerDefault = speakerDefault,
+                    enabled = true
+                )
+                if (alarm != null) {
+                    val next = AlarmModeScheduler.schedule(context, alarm)
+                    AlarmModeRepository.upsert(context, alarm.copy(nextTriggerAtMillis = next))
+                }
+            } finally {
+                if (wakeLock.isHeld) {
+                    runCatching { wakeLock.release() }
+                }
+                pendingResult.finish()
+                scope.cancel()
+            }
         }
     }
 
@@ -188,5 +214,7 @@ class AlarmModeAlarmReceiver : BroadcastReceiver() {
         private const val KEY_RUNTIME_SNOOZE_PROVIDER_NAME = "runtime_snooze_provider_name"
         private const val RUNTIME_MESSAGE_MODE_CUSTOM = "custom_audio"
         private const val RUNTIME_MESSAGE_MODE_TTS = "tts"
+        private const val WAKE_LOCK_TAG = "fakecall:alarm-mode-receiver"
+        private const val WAKE_LOCK_TIMEOUT_MS = 30_000L
     }
 }

--- a/app/src/main/java/com/upnp/fakeCall/FakeCallAlarmReceiver.kt
+++ b/app/src/main/java/com/upnp/fakeCall/FakeCallAlarmReceiver.kt
@@ -3,41 +3,67 @@ package com.upnp.fakeCall
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.os.PowerManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 
 class FakeCallAlarmReceiver : BroadcastReceiver() {
+
     override fun onReceive(context: Context, intent: Intent?) {
-        val runtimeAudioUri = intent?.getStringExtra(EXTRA_RUNTIME_AUDIO_URI).orEmpty()
-        val runtimeAudioName = intent?.getStringExtra(EXTRA_RUNTIME_AUDIO_NAME).orEmpty()
-        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-            .edit()
-            .apply {
-                if (runtimeAudioUri.isBlank()) {
-                    putBoolean(KEY_RUNTIME_AUDIO_OVERRIDE_ENABLED, false)
-                    remove(KEY_RUNTIME_AUDIO_OVERRIDE_URI)
-                    remove(KEY_RUNTIME_AUDIO_OVERRIDE_NAME)
-                } else {
-                    putBoolean(KEY_RUNTIME_AUDIO_OVERRIDE_ENABLED, true)
-                    putString(KEY_RUNTIME_AUDIO_OVERRIDE_URI, runtimeAudioUri)
-                    putString(KEY_RUNTIME_AUDIO_OVERRIDE_NAME, runtimeAudioName)
+        val pendingResult = goAsync()
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+        scope.launch {
+            val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+            val wakeLock = powerManager.newWakeLock(
+                PowerManager.PARTIAL_WAKE_LOCK,
+                WAKE_LOCK_TAG
+            ).apply { acquire(WAKE_LOCK_TIMEOUT_MS) }
+
+            try {
+                val runtimeAudioUri = intent?.getStringExtra(EXTRA_RUNTIME_AUDIO_URI).orEmpty()
+                val runtimeAudioName = intent?.getStringExtra(EXTRA_RUNTIME_AUDIO_NAME).orEmpty()
+                context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                    .edit()
+                    .apply {
+                        if (runtimeAudioUri.isBlank()) {
+                            putBoolean(KEY_RUNTIME_AUDIO_OVERRIDE_ENABLED, false)
+                            remove(KEY_RUNTIME_AUDIO_OVERRIDE_URI)
+                            remove(KEY_RUNTIME_AUDIO_OVERRIDE_NAME)
+                        } else {
+                            putBoolean(KEY_RUNTIME_AUDIO_OVERRIDE_ENABLED, true)
+                            putString(KEY_RUNTIME_AUDIO_OVERRIDE_URI, runtimeAudioUri)
+                            putString(KEY_RUNTIME_AUDIO_OVERRIDE_NAME, runtimeAudioName)
+                        }
+                    }
+                    .apply()
+                context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                    .edit()
+                    .remove(KEY_TIMER_ENDS_AT)
+                    .putInt(KEY_ACTIVE_PRESET_SLOT, -1)
+                    .apply()
+                QuickTriggerManager.refreshQuickSettingsTiles(context)
+                val callerName = intent?.getStringExtra(EXTRA_CALLER_NAME).orEmpty()
+                val callerNumber = intent?.getStringExtra(EXTRA_CALLER_NUMBER).orEmpty()
+                val providerName = intent?.getStringExtra(EXTRA_PROVIDER_NAME).orEmpty()
+
+                if (callerNumber.isBlank()) return@launch
+
+                val telecomHelper = TelecomHelper(context)
+                telecomHelper.registerOrUpdatePhoneAccount(providerName.ifBlank { context.getString(R.string.default_provider_name) })
+                if (telecomHelper.isAccountEnabled()) {
+                    telecomHelper.triggerIncomingCall(callerName, callerNumber)
                 }
+            } finally {
+                if (wakeLock.isHeld) {
+                    runCatching { wakeLock.release() }
+                }
+                pendingResult.finish()
+                scope.cancel()
             }
-            .apply()
-        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-            .edit()
-            .remove(KEY_TIMER_ENDS_AT)
-            .putInt(KEY_ACTIVE_PRESET_SLOT, -1)
-            .apply()
-        QuickTriggerManager.refreshQuickSettingsTiles(context)
-        val callerName = intent?.getStringExtra(EXTRA_CALLER_NAME).orEmpty()
-        val callerNumber = intent?.getStringExtra(EXTRA_CALLER_NUMBER).orEmpty()
-        val providerName = intent?.getStringExtra(EXTRA_PROVIDER_NAME).orEmpty()
-
-        if (callerNumber.isBlank()) return
-
-        val telecomHelper = TelecomHelper(context)
-        telecomHelper.registerOrUpdatePhoneAccount(providerName.ifBlank { context.getString(R.string.default_provider_name) })
-        if (telecomHelper.isAccountEnabled()) {
-            telecomHelper.triggerIncomingCall(callerName, callerNumber)
         }
     }
 
@@ -45,6 +71,8 @@ class FakeCallAlarmReceiver : BroadcastReceiver() {
         private const val PREFS_NAME = "fake_call_prefs"
         private const val KEY_TIMER_ENDS_AT = "timer_ends_at"
         private const val KEY_ACTIVE_PRESET_SLOT = "quick_trigger_active_preset_slot"
+        private const val WAKE_LOCK_TAG = "fakecall:alarm-receiver"
+        private const val WAKE_LOCK_TIMEOUT_MS = 30_000L
         const val EXTRA_CALLER_NAME = "extra_caller_name"
         const val EXTRA_CALLER_NUMBER = "extra_caller_number"
         const val EXTRA_PROVIDER_NAME = "extra_provider_name"

--- a/app/src/main/java/com/upnp/fakeCall/FakeCallSchedulerService.kt
+++ b/app/src/main/java/com/upnp/fakeCall/FakeCallSchedulerService.kt
@@ -10,6 +10,7 @@ import android.content.Intent
 import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.IBinder
+import android.os.PowerManager
 import androidx.core.app.NotificationCompat
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -52,17 +53,29 @@ class FakeCallSchedulerService : Service() {
 
                 scheduleJob?.cancel()
                 scheduleJob = serviceScope.launch {
-                    val telecomHelper = TelecomHelper(applicationContext)
-                    telecomHelper.registerOrUpdatePhoneAccount(providerName.ifBlank { getString(R.string.default_provider_name) })
-                    delay(delaySeconds * 1_000L)
-                    if (telecomHelper.isAccountEnabled()) {
-                        telecomHelper.triggerIncomingCall(callerName, callerNumber)
+                    val powerManager = applicationContext.getSystemService(Context.POWER_SERVICE) as PowerManager
+                    val wakeLock = powerManager.newWakeLock(
+                        PowerManager.PARTIAL_WAKE_LOCK,
+                        WAKE_LOCK_TAG
+                    ).apply { acquire((delaySeconds + 5) * 1_000L) }
+
+                    try {
+                        val telecomHelper = TelecomHelper(applicationContext)
+                        telecomHelper.registerOrUpdatePhoneAccount(providerName.ifBlank { getString(R.string.default_provider_name) })
+                        delay(delaySeconds * 1_000L)
+                        if (telecomHelper.isAccountEnabled()) {
+                            telecomHelper.triggerIncomingCall(callerName, callerNumber)
+                        }
+                    } finally {
+                        if (wakeLock.isHeld) {
+                            runCatching { wakeLock.release() }
+                        }
+                        stopForeground(STOP_FOREGROUND_REMOVE)
+                        stopSelf(startId)
                     }
-                    stopForeground(STOP_FOREGROUND_REMOVE)
-                    stopSelf(startId)
                 }
 
-                return START_NOT_STICKY
+                return START_STICKY
             }
 
             else -> {
@@ -128,6 +141,7 @@ class FakeCallSchedulerService : Service() {
     companion object {
         private const val CHANNEL_ID = "fake_call_scheduler"
         private const val NOTIFICATION_ID = 101
+        private const val WAKE_LOCK_TAG = "fakecall:scheduler-service"
 
         private const val ACTION_SCHEDULE_CALL = "com.upnp.fakeCall.action.SCHEDULE"
         private const val ACTION_CANCEL_CALL = "com.upnp.fakeCall.action.CANCEL"


### PR DESCRIPTION
## Summary

Fake calls currently do not fire when the screen is off on aggressive OEMs (Vivo OriginOS, OnePlus OxygenOS, Samsung One UI). This has been reported multiple times (#47, #33, #29) and is **not addressed** in `v2.6-alpha` (that release only contains translations + UI animations).

### Root cause

Both `FakeCallAlarmReceiver` and `AlarmModeAlarmReceiver` ran `onReceive` synchronously with no `WakeLock`. On Doze / app standby the alarm fires via `setExactAndAllowWhileIdle`, but the CPU is allowed to return to sleep immediately after `onReceive` returns — often **before** `TelecomManager.addNewIncomingCall` has finished posting the incoming call to the system. The manifest also did not declare `WAKE_LOCK` at all.

A secondary failure path: `FakeCallSchedulerService` uses `foregroundServiceType="shortService"`. OEMs that aggressively kill short FGS mid-countdown never let the coroutine `delay()` complete when the screen is off, and `START_NOT_STICKY` meant the service was gone for good.

### Changes

| File | Change |
|------|--------|
| `AndroidManifest.xml` | Declare `android.permission.WAKE_LOCK` |
| `FakeCallAlarmReceiver.kt` | `goAsync()` + `PARTIAL_WAKE_LOCK` (30s timeout) so the receiver keeps the CPU awake until `addNewIncomingCall` completes, then `pendingResult.finish()` |
| `AlarmModeAlarmReceiver.kt` | Same `goAsync()` + `WakeLock` pattern (alarm-mode fires are equally affected when screen is off) |
| `FakeCallSchedulerService.kt` | Hold a `PARTIAL_WAKE_LOCK` for `(delaySeconds + 5)s` during the countdown, and return `START_STICKY` for `ACTION_SCHEDULE_CALL` so OEMs that kill the short FGS mid-countdown can resurrect and still fire the call |

### Why this is safe

- `PARTIAL_WAKE_LOCK` is the standard pattern recommended by Android for `BroadcastReceiver` → background work (AlarmClock, WorkManager internal, etc.).
- `goAsync()` keeps the broadcast alive up to 10s by default; the wakelock covers the case where telecom registration + `addNewIncomingCall` takes longer under Doze.
- WakeLocks are always released in a `finally {}` block with an `isHeld` guard to avoid leaking.
- `START_STICKY` only applies to the schedule path; cancel path stays `START_NOT_STICKY`.

### Testing

Couldn't verify build locally (no Android SDK on this machine), but changes are additive — no existing API surface touched, all imports resolve, and the receiver lifecycle pattern matches Android docs for long-running broadcast work.

Reporters that can retest: @4tnightraven (#47 OnePlus 15), @dubai0099-ai (#33 OnePlus 11), and anyone on Vivo OriginOS / Samsung One UI — please try this build with screen off + phone locked and report back.

Fixes #47
Fixes #33
Fixes #29
